### PR TITLE
Dc mss to eess

### DIFF
--- a/campaigns/mss_d2d_to_eess/constants.py
+++ b/campaigns/mss_d2d_to_eess/constants.py
@@ -14,7 +14,9 @@ SYS_ID_TO_READABLE = {
 
 def get_specific_pattern(
     elev: int | typing.Literal["UNIFORM"],
-    eess_id: str
+    eess_id: str,
+    mask: typing.Literal["mss", "3gpp", "spurious"],
+    mss_load_factor: float
 ):
     if isinstance(elev, int):
         pass
@@ -24,7 +26,7 @@ def get_specific_pattern(
         raise ValueError(
             f"Unexpected elevation value for pattern: {elev}"
         )
-    return f"{elev}elev_{eess_id}"
+    return f"{mask}_mask_{mss_load_factor}load_{elev}elev_{eess_id}"
 
 if __name__ == "__main__":
     print("CAMPAIGN_NAME", CAMPAIGN_NAME)

--- a/campaigns/mss_d2d_to_eess/constants.py
+++ b/campaigns/mss_d2d_to_eess/constants.py
@@ -12,9 +12,15 @@ SYS_ID_TO_READABLE = {
     "eess.2200-2290MHz.system-D": "EESS D",
 }
 
+MSS_ID_TO_READABLE = {
+    "imt.2110-2200MHz.mss-dc.system3-525km": "MSS DC @525km",
+    "imt.2110-2200MHz.mss-dc.system3-340km": "MSS DC @340km",
+}
+
 def get_specific_pattern(
     elev: int | typing.Literal["UNIFORM"],
     eess_id: str,
+    imt_mss_dc_id: str,
     mask: typing.Literal["mss", "3gpp", "spurious"],
     mss_load_factor: float
 ):
@@ -26,7 +32,7 @@ def get_specific_pattern(
         raise ValueError(
             f"Unexpected elevation value for pattern: {elev}"
         )
-    return f"{mask}_mask_{mss_load_factor}load_{elev}elev_{eess_id}"
+    return f"{mask}_mask_{mss_load_factor}load_{elev}elev_{eess_id}_{imt_mss_dc_id}"
 
 if __name__ == "__main__":
     print("CAMPAIGN_NAME", CAMPAIGN_NAME)

--- a/campaigns/mss_d2d_to_eess/constants.py
+++ b/campaigns/mss_d2d_to_eess/constants.py
@@ -1,0 +1,33 @@
+from campaigns.utils.constants import SHARC_SIM_ROOT_DIR
+import typing
+
+CAMPAIGN_NAME = "mss_d2d_to_eess"
+CAMPAIGN_STR = f"campaigns/{CAMPAIGN_NAME}"
+
+CAMPAIGN_DIR = SHARC_SIM_ROOT_DIR / CAMPAIGN_STR
+INPUTS_DIR = CAMPAIGN_DIR / "input/"
+
+SYS_ID_TO_READABLE = {
+    "eess.2200-2290MHz.system-B": "EESS B",
+    "eess.2200-2290MHz.system-D": "EESS D",
+}
+
+def get_specific_pattern(
+    elev: int | typing.Literal["UNIFORM"],
+    eess_id: str
+):
+    if isinstance(elev, int):
+        pass
+    elif isinstance(elev, str) and elev.lower() == "uniform":
+        elev = elev.lower() + "_"
+    else:
+        raise ValueError(
+            f"Unexpected elevation value for pattern: {elev}"
+        )
+    return f"{elev}elev_{eess_id}"
+
+if __name__ == "__main__":
+    print("CAMPAIGN_NAME", CAMPAIGN_NAME)
+    print("CAMPAIGN_STR", CAMPAIGN_STR)
+    print("CAMPAIGN_DIR", CAMPAIGN_DIR)
+    print("INPUTS_DIR", INPUTS_DIR)

--- a/campaigns/mss_d2d_to_eess/generate_inputs.py
+++ b/campaigns/mss_d2d_to_eess/generate_inputs.py
@@ -1,6 +1,12 @@
+import numpy as np
+
 from campaigns.utils.parameters_factory import ParametersFactory
 from campaigns.utils.dump_parameters import dump_parameters
-from campaigns.utils.constants import ROOT_DIR
+
+from sharc.parameters.antenna.parameters_antenna_s1528 import ParametersAntennaS1528
+from sharc.antenna.antenna_s1528 import AntennaS1528Taylor
+
+from campaigns.mss_d2d_to_eess.constants import CAMPAIGN_STR, CAMPAIGN_NAME, get_specific_pattern, INPUTS_DIR
 
 SEED = 0xeffec7  # Example seed value, can be changed as needed
 general = {
@@ -9,40 +15,215 @@ general = {
     # Number of simulation snapshots
     ###########################################################################
     "num_snapshots": 10000,
-    "enable_cochannel": True,
-    "enable_adjacent_channel": False,
     ###########################################################################,
     # if FALSE, then a new output directory is created,
     "overwrite_output": False,
     ###########################################################################,
     # output destination folder - this is relative SHARC/sharc directory,
-    "output_dir": "campaigns/mss_d2d_to_eess/output/",
-    "output_dir_prefix": "output_mss_d2d_eess",
+    "output_dir": f"{CAMPAIGN_STR}/output/",
+    "output_dir_prefix": "to-update",
     "system": "SINGLE_EARTH_STATION",
     "imt_link": "DOWNLINK",
 }
 
-factory = ParametersFactory()
+def get_taylor_cell_radius(
+    params_s1528: ParametersAntennaS1528,
+    sat_alt_km: float,
+    attempt_max_angle: float = 10.0,
+    attempt_resolution: int = int(1e6)
+):
+    antenna = AntennaS1528Taylor(
+        params_s1528
+    )
+    off_axis = np.linspace(0, attempt_max_angle, attempt_resolution)
+    gains = antenna.calculate_gain(
+        off_axis_angle_vec=off_axis,
+        # theta is set to 0 since it makes no difference
+        # when antenna pattern is circular
+        theta_vec=0,
+    )
+    angle_7dB_i = np.where(gains <= params_s1528.antenna_gain - 7)[0][0]
+    angle_7dB = off_axis[angle_7dB_i]
+    cell_radius = np.tan(np.deg2rad(angle_7dB)) * sat_alt_km * 1e3
 
-params = factory.load_from_id(
-    "id: imt.2110-2200MHz.mss-dc.system3"
-).load_from_id(
-    "eess.system-b"
-).load_from_dict(
-    {"general": general}
-).build()
+    return int(cell_radius)
 
-params["mss_d2d"]["frequency"] = 2167.5
-params["mss_d2d"]["bandwidth"] = 5.0
-params["mss_d2d"]["cell_radius"] = 39475.0
+def estimate_eess_antenna_diameter(
+    frequency,
+    antenna_gain,
+    antenna_efficiency
+):
+    # antenna efficiency:
+    n = antenna_efficiency
+    lmbda = 3e8 / (frequency * 1e6)
+    G = 10**(antenna_gain / 10)
+    return float(np.round(
+        lmbda * np.sqrt(G / n) / np.pi, decimals=2
+    ))
 
-file = ROOT_DIR / "test_ul.yaml"
-dump_parameters(
-    file, params
-)
+def generate_inputs():
+    OUTPUT_START_NAME = f"output_{CAMPAIGN_NAME}_"
+    PARAMETER_START_NAME = f"parameter_{CAMPAIGN_NAME}_"
 
-file = ROOT_DIR / "test_dl.yaml"
-params["general"]["imt_link"] = "DOWNLINK"
-dump_parameters(
-    file, params
-)
+    print(f"Inputs going to directory '{INPUTS_DIR}'")
+
+    factory = ParametersFactory()
+
+    for eess_sys_id in [
+        "eess.2200-2290MHz.system-B",
+        "eess.2200-2290MHz.system-D",
+    ]:
+        print(f"[Building params for {eess_sys_id}]")
+
+        params = factory.load_from_id(
+            "imt.2110-2200MHz.mss-dc.system3-525km"
+        ).load_from_id(
+            eess_sys_id
+        ).load_from_dict(
+            {"general": general}
+        ).build()
+
+        ##########
+        # Scenario
+
+        params.general.enable_adjacent_channel = True
+        params.general.enable_cochannel = False
+        params.imt.interfered_with = False
+        # NOTE: needed for performance. Discards unnecessary calcs.
+        params.imt.imt_dl_intra_sinr_calculation_disabled = True
+
+        # NOTE: consider using 2197.5 MHz for directly adjacent simulation
+        params.imt.frequency = 2160.0
+        params.imt.adjacent_ch_emissions = "SPECTRAL_MASK"
+
+        params.single_earth_station.frequency = 2200 + params.single_earth_station.bandwidth / 2
+        # NOTE: it seems that ACS was not used in previous iterations
+        params.single_earth_station.adjacent_ch_reception = "ACS"
+
+        # Geometry
+        ## Refernce latitude and longitude taken from INPE/Cachoeria Paulista
+        params.imt.topology.central_latitude = -22.681603
+        params.imt.topology.central_longitude = -45.002609
+        params.imt.topology.central_altitude = 563
+
+        # position ES at reference
+        eess_geom = params.single_earth_station.geometry
+        eess_geom.location.type = "FIXED"
+        eess_geom.location.fixed.x = 0
+        eess_geom.location.fixed.y = 0
+
+        # Parameters used for P.619
+        # WARNING: Remember to set the lut in propagation/Dataset!
+        params.single_earth_station.season = "SUMMER"
+        # params.single_earth_station.channel_model = "FSPL"
+        params.single_earth_station.channel_model = "P619"
+        params.single_earth_station.param_p619.earth_station_lat_deg = params.imt.topology.central_latitude
+        params.single_earth_station.param_p619.earth_station_alt_m = params.imt.topology.central_altitude
+        # TODO: decide on these params:
+        params.single_earth_station.param_p619.mean_clutter_height = "low"
+        params.single_earth_station.param_p619.below_rooftop = 50
+
+        ##########
+        # MSS DC Parameters
+
+        # Beam pointing
+        params.imt.topology.mss_dc.beam_positioning.type = "SERVICE_GRID"
+        params.imt.topology.mss_dc.beam_positioning.service_grid.country_names = ["Brazil"]
+        # this is distance in km so that actual best satellite is used for each grid point
+        angle_dist_between_planes = 360 / params.imt.topology.mss_dc.orbits[0].n_planes
+        margin = -np.ceil((angle_dist_between_planes / 2) * 111)
+        params.imt.topology.mss_dc.beam_positioning.service_grid.eligible_sats_margin_from_border = int(margin)
+
+        # Beam is active if satellite
+        params.imt.topology.mss_dc.sat_is_active_if.conditions = [
+            "LAT_LONG_INSIDE_COUNTRY",
+            "MINIMUM_ELEVATION_FROM_ES",
+        ]
+        params.imt.topology.mss_dc.sat_is_active_if.lat_long_inside_country.country_names = ["Brazil"]
+        params.imt.topology.mss_dc.sat_is_active_if.lat_long_inside_country.margin_from_border = \
+            params.imt.topology.mss_dc.beam_positioning.service_grid.eligible_sats_margin_from_border
+
+        # Set adjacent antenna pattern
+        # NOTE: currently adjacent antenna pattern is
+        # M2101 single element
+        # this may not be the best modelling
+        # TODO: have some way of defining this at parameter level?
+        # maybe have some modifier so that we may import `id:adjacent`?
+        # or some "parameter level" utility for mounting some
+        # kinds of parameter?
+        params.imt.bs.antenna.pattern = "ARRAY"
+
+        # Get cell radius based on co-channel antenna pattern
+        params.imt.bs.antenna.itu_r_s_1528.frequency = params.imt.frequency
+        params.imt.bs.antenna.set_external_parameters(
+            frequency=params.imt.frequency,
+        )
+        # params.imt.validate("propagating-imt")
+        params.imt.topology.mss_dc.beam_radius = get_taylor_cell_radius(
+            params.imt.bs.antenna.itu_r_s_1528,
+            params.imt.topology.mss_dc.orbits[0].apogee_alt_km,
+        )
+
+        ##########
+        # EESS Parameters
+        if params.single_earth_station.antenna.pattern == "ITU-R S.465":
+            antenna_model_param = params.single_earth_station.antenna.itu_r_s_465
+        else:
+            raise ValueError(
+                f"Script cannot deal with antenna pattern {params.single_earth_station.antenna.pattern}"
+            )
+
+        # antenna efficiency
+        n = 0.5
+        diam = estimate_eess_antenna_diameter(
+            params.single_earth_station.frequency,
+            params.single_earth_station.antenna.gain,
+            n
+        )
+
+        print(
+            f"\t- An antenna diameter of {diam} "
+            f"has been assumed for an efficiency of {n}."
+        )
+        antenna_model_param.diameter = diam
+
+        eess_geom.azimuth.type = "UNIFORM_DIST"
+        eess_geom.azimuth.uniform_dist.max = 180.
+        eess_geom.azimuth.uniform_dist.min = -180.
+
+        for eess_elev in [
+            5, 30, 60, 90
+        ]:
+            params.single_earth_station.geometry.elevation.type = "FIXED"
+            params.single_earth_station.geometry.elevation.fixed = eess_elev
+            specific = get_specific_pattern(eess_elev, eess_sys_id)
+            params.general.output_dir_prefix = OUTPUT_START_NAME + specific
+
+            dump_parameters(
+                INPUTS_DIR / (PARAMETER_START_NAME + specific + ".yaml"),
+                params,
+            )
+
+        # also do uniform dist of elevation angles
+        params.single_earth_station.geometry.elevation.type = "UNIFORM_DIST"
+        params.single_earth_station.geometry.elevation.uniform_dist.min = 5
+        params.single_earth_station.geometry.elevation.uniform_dist.max = 90
+
+        specific = get_specific_pattern("uniform", eess_sys_id)
+        params.general.output_dir_prefix = OUTPUT_START_NAME + specific
+
+        dump_parameters(
+            INPUTS_DIR / (PARAMETER_START_NAME + specific + ".yaml"),
+            params,
+        )
+
+def clear_inputs():
+    print(f"Clearing inputs from dir '{INPUTS_DIR}'")
+    # removes all current inputs in directory
+    for item in INPUTS_DIR.iterdir():
+        if item.is_file() and item.name.endswith(".yaml"):
+            item.unlink()
+
+if __name__ == "__main__":
+    clear_inputs()
+    generate_inputs()

--- a/campaigns/mss_d2d_to_eess/generate_inputs.py
+++ b/campaigns/mss_d2d_to_eess/generate_inputs.py
@@ -1,0 +1,48 @@
+from campaigns.utils.parameters_factory import ParametersFactory
+from campaigns.utils.dump_parameters import dump_parameters
+from campaigns.utils.constants import ROOT_DIR
+
+SEED = 0xeffec7  # Example seed value, can be changed as needed
+general = {
+    "seed": SEED,
+    ###########################################################################
+    # Number of simulation snapshots
+    ###########################################################################
+    "num_snapshots": 10000,
+    "enable_cochannel": True,
+    "enable_adjacent_channel": False,
+    ###########################################################################,
+    # if FALSE, then a new output directory is created,
+    "overwrite_output": False,
+    ###########################################################################,
+    # output destination folder - this is relative SHARC/sharc directory,
+    "output_dir": "campaigns/mss_d2d_to_eess/output/",
+    "output_dir_prefix": "output_mss_d2d_eess",
+    "system": "SINGLE_EARTH_STATION",
+    "imt_link": "DOWNLINK",
+}
+
+factory = ParametersFactory()
+
+params = factory.load_from_id(
+    "id: imt.2110-2200MHz.mss-dc.system3"
+).load_from_id(
+    "eess.system-b"
+).load_from_dict(
+    {"general": general}
+).build()
+
+params["mss_d2d"]["frequency"] = 2167.5
+params["mss_d2d"]["bandwidth"] = 5.0
+params["mss_d2d"]["cell_radius"] = 39475.0
+
+file = ROOT_DIR / "test_ul.yaml"
+dump_parameters(
+    file, params
+)
+
+file = ROOT_DIR / "test_dl.yaml"
+params["general"]["imt_link"] = "DOWNLINK"
+dump_parameters(
+    file, params
+)

--- a/campaigns/mss_d2d_to_eess/generate_inputs.py
+++ b/campaigns/mss_d2d_to_eess/generate_inputs.py
@@ -108,20 +108,28 @@ def generate_inputs():
 
         # position ES at reference
         eess_geom = params.single_earth_station.geometry
+        eess_geom.height = 15
         eess_geom.location.type = "FIXED"
         eess_geom.location.fixed.x = 0
         eess_geom.location.fixed.y = 0
+
+        eess_geom.azimuth.type = "UNIFORM_DIST"
+        eess_geom.azimuth.uniform_dist.max = 180.
+        eess_geom.azimuth.uniform_dist.min = -180.
 
         # Parameters used for P.619
         # WARNING: Remember to set the lut in propagation/Dataset!
         params.single_earth_station.season = "SUMMER"
         # params.single_earth_station.channel_model = "FSPL"
         params.single_earth_station.channel_model = "P619"
+        # 3dB polarization loss, as suggested by P.619
+        params.single_earth_station.polarization_loss = 3
+
         params.single_earth_station.param_p619.earth_station_lat_deg = params.imt.topology.central_latitude
         params.single_earth_station.param_p619.earth_station_alt_m = params.imt.topology.central_altitude
         # TODO: decide on these params:
         params.single_earth_station.param_p619.mean_clutter_height = "low"
-        params.single_earth_station.param_p619.below_rooftop = 50
+        params.single_earth_station.param_p619.below_rooftop = 0
 
         ##########
         # MSS DC Parameters
@@ -144,14 +152,8 @@ def generate_inputs():
             params.imt.topology.mss_dc.beam_positioning.service_grid.eligible_sats_margin_from_border
 
         # Set adjacent antenna pattern
-        # NOTE: currently adjacent antenna pattern is
-        # M2101 single element
-        # this may not be the best modelling
-        # TODO: have some way of defining this at parameter level?
-        # maybe have some modifier so that we may import `id:adjacent`?
-        # or some "parameter level" utility for mounting some
-        # kinds of parameter?
-        params.imt.bs.antenna.pattern = "ARRAY"
+        # Editor's note say that 1528 should still be used in adjacent studies
+        # params.imt.bs.antenna.pattern = "ARRAY"
 
         # Get cell radius based on co-channel antenna pattern
         params.imt.bs.antenna.itu_r_s_1528.frequency = params.imt.frequency
@@ -186,10 +188,6 @@ def generate_inputs():
             f"has been assumed for an efficiency of {n}."
         )
         antenna_model_param.diameter = diam
-
-        eess_geom.azimuth.type = "UNIFORM_DIST"
-        eess_geom.azimuth.uniform_dist.max = 180.
-        eess_geom.azimuth.uniform_dist.min = -180.
 
         for eess_elev in [
             5, 30, 60, 90

--- a/campaigns/mss_d2d_to_eess/generate_inputs.py
+++ b/campaigns/mss_d2d_to_eess/generate_inputs.py
@@ -69,177 +69,172 @@ def generate_inputs():
 
     factory = ParametersFactory()
 
-    for eess_sys_id in [
-        "eess.2200-2290MHz.system-B",
-        "eess.2200-2290MHz.system-D",
+    for imt_mss_dc_id in [
+        "imt.2110-2200MHz.mss-dc.system3-525km",
+        "imt.2110-2200MHz.mss-dc.system3-340km",
     ]:
-        print(f"[Building params for {eess_sys_id}]")
+        for eess_sys_id in [
+            "eess.2200-2290MHz.system-B",
+            "eess.2200-2290MHz.system-D",
+        ]:
+            print(f"[Building params for {imt_mss_dc_id} -> {eess_sys_id}]")
 
-        params = factory.load_from_id(
-            "imt.2110-2200MHz.mss-dc.system3-525km"
-        ).load_from_id(
-            eess_sys_id
-        ).load_from_dict(
-            {"general": general}
-        ).build()
+            params = factory.load_from_id(
+                imt_mss_dc_id
+            ).load_from_id(
+                eess_sys_id
+            ).load_from_dict(
+                {"general": general}
+            ).build()
 
-        ##########
-        # Scenario
+            ##########
+            # Scenario
 
-        params.general.enable_adjacent_channel = True
-        params.general.enable_cochannel = False
-        params.imt.interfered_with = False
-        # NOTE: needed for performance. Discards unnecessary calcs.
-        params.imt.imt_dl_intra_sinr_calculation_disabled = True
+            params.general.enable_adjacent_channel = True
+            params.general.enable_cochannel = False
+            params.imt.interfered_with = False
+            # NOTE: needed for performance. Discards unnecessary calcs.
+            params.imt.imt_dl_intra_sinr_calculation_disabled = True
 
-        params.imt.adjacent_ch_emissions = "SPECTRAL_MASK"
+            params.imt.adjacent_ch_emissions = "SPECTRAL_MASK"
 
-        params.single_earth_station.frequency = 2200 + params.single_earth_station.bandwidth / 2
-        # NOTE: it seems that ACS was not used in previous iterations
-        params.single_earth_station.adjacent_ch_reception = "ACS"
+            params.single_earth_station.frequency = 2200 + params.single_earth_station.bandwidth / 2
+            # NOTE: it seems that ACS was not used in previous iterations
+            params.single_earth_station.adjacent_ch_reception = "ACS"
 
-        # Geometry
-        ## Refernce latitude and longitude taken from INPE/Cachoeria Paulista
-        params.imt.topology.central_latitude = -22.681603
-        params.imt.topology.central_longitude = -45.002609
-        params.imt.topology.central_altitude = 563
+            # Geometry
+            ## Refernce latitude and longitude taken from Cuiaba station
+            params.imt.topology.central_latitude = -15.3300
+            params.imt.topology.central_longitude = -56.0400
+            params.imt.topology.central_altitude = 165
 
-        # position ES at reference
-        eess_geom = params.single_earth_station.geometry
-        eess_geom.height = 15
-        eess_geom.location.type = "FIXED"
-        eess_geom.location.fixed.x = 0
-        eess_geom.location.fixed.y = 0
+            # position ES at reference
+            eess_geom = params.single_earth_station.geometry
+            eess_geom.height = 15
+            eess_geom.location.type = "FIXED"
+            eess_geom.location.fixed.x = 0
+            eess_geom.location.fixed.y = 0
 
-        eess_geom.azimuth.type = "UNIFORM_DIST"
-        eess_geom.azimuth.uniform_dist.max = 180.
-        eess_geom.azimuth.uniform_dist.min = -180.
+            eess_geom.azimuth.type = "UNIFORM_DIST"
+            eess_geom.azimuth.uniform_dist.max = 180.
+            eess_geom.azimuth.uniform_dist.min = -180.
 
-        # Parameters used for P.619
-        # WARNING: Remember to set the lut in propagation/Dataset!
-        params.single_earth_station.season = "SUMMER"
-        # params.single_earth_station.channel_model = "FSPL"
-        params.single_earth_station.channel_model = "P619"
-        # 3dB polarization loss, as suggested by P.619
-        params.single_earth_station.polarization_loss = 3
+            # Parameters used for P.619
+            # WARNING: Remember to set the lut in propagation/Dataset!
+            params.single_earth_station.season = "SUMMER"
+            # params.single_earth_station.channel_model = "FSPL"
+            params.single_earth_station.channel_model = "P619"
+            # 3dB polarization loss, as suggested by P.619
+            params.single_earth_station.polarization_loss = 3
 
-        params.single_earth_station.param_p619.earth_station_lat_deg = params.imt.topology.central_latitude
-        params.single_earth_station.param_p619.earth_station_alt_m = params.imt.topology.central_altitude
-        # TODO: decide on these params:
-        params.single_earth_station.param_p619.mean_clutter_height = "low"
-        params.single_earth_station.param_p619.below_rooftop = 0
+            params.single_earth_station.param_p619.earth_station_lat_deg = params.imt.topology.central_latitude
+            params.single_earth_station.param_p619.earth_station_alt_m = params.imt.topology.central_altitude
+            # TODO: decide on these params:
+            params.single_earth_station.param_p619.mean_clutter_height = "low"
+            params.single_earth_station.param_p619.below_rooftop = 0
 
-        ##########
-        # MSS DC Parameters
+            ##########
+            # MSS DC Parameters
 
-        # Beam pointing
-        params.imt.topology.mss_dc.beam_positioning.type = "SERVICE_GRID"
-        params.imt.topology.mss_dc.beam_positioning.service_grid.country_names = ["Brazil"]
-        # this is distance in km so that actual best satellite is used for each grid point
-        angle_dist_between_planes = 360 / params.imt.topology.mss_dc.orbits[0].n_planes
-        margin = -np.ceil((angle_dist_between_planes / 2) * 111)
-        params.imt.topology.mss_dc.beam_positioning.service_grid.eligible_sats_margin_from_border = int(margin)
+            # Beam pointing
+            params.imt.topology.mss_dc.beam_positioning.type = "SERVICE_GRID"
+            params.imt.topology.mss_dc.beam_positioning.service_grid.country_names = [
+                "Brazil", "Argentina", "Bolivia", "Chile", "Peru", "Paraguay", "Uruguay"
+            ]
+            # this is distance in km so that actual best satellite is used for each grid point
+            angle_dist_between_planes = 360 / params.imt.topology.mss_dc.orbits[0].n_planes
+            margin = -np.ceil((angle_dist_between_planes / 2) * 111)
+            params.imt.topology.mss_dc.beam_positioning.service_grid.eligible_sats_margin_from_border = int(margin)
 
-        # Beam is active if satellite
-        params.imt.topology.mss_dc.sat_is_active_if.conditions = [
-            "LAT_LONG_INSIDE_COUNTRY",
-            "MINIMUM_ELEVATION_FROM_ES",
-        ]
-        params.imt.topology.mss_dc.sat_is_active_if.lat_long_inside_country.country_names = ["Brazil"]
-        params.imt.topology.mss_dc.sat_is_active_if.lat_long_inside_country.margin_from_border = \
-            params.imt.topology.mss_dc.beam_positioning.service_grid.eligible_sats_margin_from_border
+            # Beam is active if satellite
+            params.imt.topology.mss_dc.sat_is_active_if.conditions = [
+                "LAT_LONG_INSIDE_COUNTRY",
+                "MINIMUM_ELEVATION_FROM_ES",
+            ]
+            params.imt.topology.mss_dc.sat_is_active_if.lat_long_inside_country.country_names = [
+                "Brazil", "Argentina", "Bolivia", "Chile", "Peru", "Paraguay", "Uruguay"
+            ]
+            params.imt.topology.mss_dc.sat_is_active_if.lat_long_inside_country.margin_from_border = \
+                params.imt.topology.mss_dc.beam_positioning.service_grid.eligible_sats_margin_from_border
 
-        # Set adjacent antenna pattern
-        # Editor's note say that 1528 should still be used in adjacent studies
-        # params.imt.bs.antenna.pattern = "ARRAY"
+            # Set adjacent antenna pattern
+            # Editor's note say that 1528 should still be used in adjacent studies
+            # params.imt.bs.antenna.pattern = "ARRAY"
 
-        # Get cell radius based on co-channel antenna pattern
-        params.imt.frequency = 2197.5
-        params.imt.bs.antenna.itu_r_s_1528.frequency = params.imt.frequency
-        params.imt.bs.antenna.set_external_parameters(
-            frequency=params.imt.frequency,
-        )
-        # params.imt.validate("propagating-imt")
-        params.imt.topology.mss_dc.beam_radius = get_taylor_cell_radius(
-            params.imt.bs.antenna.itu_r_s_1528,
-            params.imt.topology.mss_dc.orbits[0].apogee_alt_km,
-        )
-        print(f"A cell radius of {params.imt.topology.mss_dc.beam_radius} will be used for MSS DC")
+            # Get cell radius based on co-channel antenna pattern
+            params.imt.frequency = 2197.5
+            params.imt.bs.antenna.itu_r_s_1528.frequency = params.imt.frequency
+            params.imt.bs.antenna.set_external_parameters(
+                frequency=params.imt.frequency,
+            )
+            # params.imt.validate("propagating-imt")
+            params.imt.topology.mss_dc.beam_radius = get_taylor_cell_radius(
+                params.imt.bs.antenna.itu_r_s_1528,
+                params.imt.topology.mss_dc.orbits[0].apogee_alt_km,
+            )
+            print(f"A cell radius of {params.imt.topology.mss_dc.beam_radius} will be used for MSS DC")
 
-        ##########
-        # EESS Parameters
-        if params.single_earth_station.antenna.pattern == "ITU-R S.465":
-            antenna_model_param = params.single_earth_station.antenna.itu_r_s_465
-        else:
-            raise ValueError(
-                f"Script cannot deal with antenna pattern {params.single_earth_station.antenna.pattern}"
+            ##########
+            # EESS Parameters
+            if params.single_earth_station.antenna.pattern == "ITU-R S.465":
+                antenna_model_param = params.single_earth_station.antenna.itu_r_s_465
+            else:
+                raise ValueError(
+                    f"Script cannot deal with antenna pattern {params.single_earth_station.antenna.pattern}"
+                )
+
+            # antenna efficiency
+            n = 0.5
+            diam = estimate_eess_antenna_diameter(
+                params.single_earth_station.frequency,
+                params.single_earth_station.antenna.gain,
+                n
             )
 
-        # antenna efficiency
-        n = 0.5
-        diam = estimate_eess_antenna_diameter(
-            params.single_earth_station.frequency,
-            params.single_earth_station.antenna.gain,
-            n
-        )
+            print(
+                f"\t- An antenna diameter of {diam} "
+                f"has been assumed for an efficiency of {n}."
+            )
+            antenna_model_param.diameter = diam
 
-        print(
-            f"\t- An antenna diameter of {diam} "
-            f"has been assumed for an efficiency of {n}."
-        )
-        antenna_model_param.diameter = diam
-
-        params.imt.spurious_emissions = -13
-        for load in [
-            0.2,
-            0.5,
-        ]:
-            params.imt.bs.load_probability = load
-            for mask in [
-                "MSS",
-                "3GPP E-UTRA",
-                "spurious"
+            params.imt.spurious_emissions = -13
+            for load in [
+                0.2,
+                0.5,
             ]:
-                readable_mask = {
-                    "MSS": "mss",
-                    "3GPP E-UTRA": "3gpp",
-                    "spurious": "spurious"
-                }[mask]
-
-                if mask == "spurious":
-                    # there is no need to simulate both masks since
-                    # for this freq only spurious emissions reach eess
-                    params.imt.spectral_mask = "3GPP E-UTRA"
-                    params.imt.frequency = 2167.5
-                else:
-                    params.imt.frequency = 2197.5
-                    params.imt.spectral_mask = mask
-
-                for eess_elev in [
-                    5, 30, 60, 90
+                params.imt.bs.load_probability = load
+                for mask in [
+                    "MSS",
+                    "spurious"
                 ]:
-                    params.single_earth_station.geometry.elevation.type = "FIXED"
-                    params.single_earth_station.geometry.elevation.fixed = eess_elev
-                    specific = get_specific_pattern(eess_elev, eess_sys_id, readable_mask, load)
+                    readable_mask = {
+                        "MSS": "mss",
+                        "spurious": "spurious"
+                    }[mask]
+
+                    if mask == "spurious":
+                        # there is no need to simulate both masks since
+                        # for this freq only spurious emissions reach eess
+                        params.imt.spectral_mask = "MSS"
+                        params.imt.frequency = 2167.5
+                    else:
+                        params.imt.frequency = 2197.5
+                        params.imt.spectral_mask = mask
+
+                    # also do uniform dist of elevation angles
+                    params.single_earth_station.geometry.elevation.type = "UNIFORM_DIST"
+                    params.single_earth_station.geometry.elevation.uniform_dist.min = 5.
+                    params.single_earth_station.geometry.elevation.uniform_dist.max = 90.
+
+                    specific = get_specific_pattern(
+                        "uniform", eess_sys_id, imt_mss_dc_id, readable_mask, load
+                    )
                     params.general.output_dir_prefix = OUTPUT_START_NAME + specific
 
                     dump_parameters(
                         INPUTS_DIR / (PARAMETER_START_NAME + specific + ".yaml"),
                         params,
                     )
-
-                # also do uniform dist of elevation angles
-                params.single_earth_station.geometry.elevation.type = "UNIFORM_DIST"
-                params.single_earth_station.geometry.elevation.uniform_dist.min = 5
-                params.single_earth_station.geometry.elevation.uniform_dist.max = 90
-
-                specific = get_specific_pattern("uniform", eess_sys_id, readable_mask, load)
-                params.general.output_dir_prefix = OUTPUT_START_NAME + specific
-
-                dump_parameters(
-                    INPUTS_DIR / (PARAMETER_START_NAME + specific + ".yaml"),
-                    params,
-                )
 
 def clear_inputs():
     print(f"Clearing inputs from dir '{INPUTS_DIR}'")

--- a/campaigns/mss_d2d_to_eess/plot_fps.py
+++ b/campaigns/mss_d2d_to_eess/plot_fps.py
@@ -1,0 +1,61 @@
+# plot footprints
+from sharc.parameters.parameters import Parameters
+from sharc.satellite.scripts.plot_footprints import plot_fp, FootPrintOpts
+from sharc.support.sharc_geom import GeometryConverter
+
+from campaigns.mss_d2d_to_eess.constants import INPUTS_DIR
+
+from pathlib import Path
+
+if __name__ == "__main__":
+    # print("INPUTS_DIR", INPUTS_DIR)
+    names = [
+        "parameter_mss_d2d_to_eess_mss_mask_1load_uniform_elev_eess.2200-2290MHz.system-D.yaml"
+    ]
+    for param_name in names:
+        param_file = INPUTS_DIR / param_name
+        # param_file = script_dir / "../input/parameters_mss_d2d_to_imt_cross_border_0km_random_pointing_1beam_dl.yaml"
+        param_file = param_file.resolve()
+        print("File at:")
+        print(f"  '{param_file}'")
+
+        parameters = Parameters()
+        parameters.set_file_name(param_file)
+        parameters.read_params()
+
+        geoconv = GeometryConverter()
+
+        geoconv.set_reference(
+            parameters.imt.topology.central_latitude,
+            parameters.imt.topology.central_longitude,
+            parameters.imt.topology.central_altitude,
+        )
+        opts = FootPrintOpts(
+            resolution=100,
+            show_service_grid_if_possible=False,
+            seed=1,
+            discretize=True,
+            colors=['rgb(220, 220, 220)', '#fc8d59', '#7f0000']
+        )
+        params = parameters.mss_d2d
+        params.orbits = parameters.imt.topology.mss_dc.orbits
+        params.sat_is_active_if = parameters.imt.topology.mss_dc.sat_is_active_if
+        params.beam_positioning = parameters.imt.topology.mss_dc.beam_positioning
+        params.beam_radius = parameters.imt.topology.mss_dc.cell_radius
+        params.frequency = parameters.imt.frequency
+        # params.beams_load_factor = parameters.imt.bs.load_probability
+        params.beams_load_factor = 1.0
+        if parameters.imt.bs.antenna.pattern != "ITU-R-S.1528-Taylor":
+            raise ValueError("Antenna pattern not supported by this plot script")
+        params.antenna_pattern = "ITU-R-S.1528-Taylor"
+        params.antenna_s1528 = parameters.imt.bs.antenna.itu_r_s_1528
+
+        params.sat_is_active_if.conditions = [
+            "LAT_LONG_INSIDE_COUNTRY",
+        ]
+        fp = plot_fp(params, geoconv, opts)
+        fp.show()
+
+        # Path("figs").mkdir(parents=True, exist_ok=True)
+        # fp.write_image(f"figs/{param_name}.png")
+

--- a/campaigns/mss_d2d_to_eess/plot_results.py
+++ b/campaigns/mss_d2d_to_eess/plot_results.py
@@ -1,0 +1,138 @@
+import os
+from sharc.results import Results
+from sharc.post_processor import PostProcessor
+
+from campaigns.mss_d2d_to_eess.constants import CAMPAIGN_DIR, SYS_ID_TO_READABLE
+
+auto_open = True
+
+post_processor = PostProcessor()
+
+# Samples to plot CCDF from
+samples_for_ccdf = [
+    "system_dl_interf_power_per_mhz"
+]
+
+samples_for_cdf = [
+    "imt_system_antenna_gain",
+    "imt_system_path_loss",
+    "system_dl_interf_power",
+    "system_imt_antenna_gain",
+    "system_inr", "ccdf"
+]
+
+ccdf_results = Results.load_many_from_dir(
+    CAMPAIGN_DIR / "output",
+    # filter_fn=lambda x: "mss_d2d_to_eess" in x,
+    only_latest=True,
+    only_samples=samples_for_ccdf)
+
+cdf_results = Results.load_many_from_dir(
+    CAMPAIGN_DIR / "output",
+    # filter_fn=lambda x: "mss_d2d_to_eess" in x,
+    only_latest=True,
+    only_samples=samples_for_cdf)
+
+
+def linestyle_getter(results):
+    """
+    Determine the line style for plotting based on the results' output directory.
+
+    Parameters
+    ----------
+    results : Results
+        The results object containing the output directory information.
+
+    Returns
+    -------
+    str
+        The line style to use for plotting (e.g., 'dash' or 'solid').
+    """
+    if "system-D" in results.output_directory:
+        return "dash"
+    return "solid"
+
+
+post_processor.add_results_linestyle_getter(linestyle_getter)
+
+for sys_name in [
+    "eess.2200-2290MHz.system-B",
+    "eess.2200-2290MHz.system-D",
+]:
+    for elev in [5, 30, 60, 90, "uniform_"]:
+        if elev == "uniform_":
+            readable_elev = "Elev = Unif. Dist."
+        else:
+            readable_elev = f"Elev = {elev}º"
+        # IMT-MSS-D2D-DL to EESS
+        post_processor\
+            .add_plot_legend_pattern(
+                dir_name_contains=f"{elev}elev_{sys_name}",
+                legend=f"{SYS_ID_TO_READABLE[sys_name]}, {readable_elev}"
+            )
+# ^: typing.List[Results]
+
+plots = post_processor.generate_ccdf_plots_from_results(
+    ccdf_results
+)
+
+post_processor.add_plots(plots)
+
+plots = post_processor.generate_cdf_plots_from_results(
+    cdf_results
+)
+
+post_processor.add_plots(plots)
+
+# plots = post_processor.generate_ccdf_plots_from_results(
+#     many_results
+# )
+
+# post_processor.add_plots(plots)
+
+# Add a protection criteria line:
+protection_criteria = -154.0  # dBm/MHz
+perc_time = 0.01
+system_dl_interf_power_per_mhz = post_processor.get_plot_by_results_attribute_name(
+    "system_dl_interf_power_per_mhz", plot_type="ccdf")
+system_dl_interf_power_per_mhz.add_vline(
+    protection_criteria,
+    line_dash="dash",
+    annotation=dict(
+        text="Protection Criteria: " +
+        str(protection_criteria) +
+        " dB[W/MHz]",
+        xref="x",
+        yref="y",
+        x=protection_criteria +
+        0.5,
+        y=0.8,
+        font=dict(
+            size=12,
+             color="red")))
+system_dl_interf_power_per_mhz.add_hline(perc_time, line_dash="dash", annotation=dict(
+    text="Time Percentage: " + str(perc_time * 100) + "%",
+    xref="x", yref="y",
+    x=protection_criteria + 0.5, y=perc_time + 0.01,
+    font=dict(size=12, color="blue")
+))
+
+
+attributes_to_plot = [
+    ("imt_system_antenna_gain", "cdf"),
+    ("imt_system_path_loss", "cdf"),
+    ("system_dl_interf_power", "cdf"),
+    ("system_dl_interf_power_per_mhz", "ccdf"),
+    ("system_imt_antenna_gain", "cdf"),
+    ("system_inr", "cdf"),
+]
+
+HTMLS_DIR = CAMPAIGN_DIR / "output" / "htmls"
+HTMLS_DIR.mkdir(exist_ok=True)
+print(f"Saving plots in {HTMLS_DIR}")
+for attr, plot_type in attributes_to_plot:
+    file = HTMLS_DIR / f"{attr}.html"
+    post_processor\
+        .get_plot_by_results_attribute_name(attr, plot_type=plot_type)\
+        .write_html(file=file, include_plotlyjs="cdn", auto_open=auto_open)
+

--- a/campaigns/mss_d2d_to_eess/plot_results.py
+++ b/campaigns/mss_d2d_to_eess/plot_results.py
@@ -1,5 +1,5 @@
-import os
-from sharc.results import Results
+import numpy as np
+from sharc.results import Results, SampleList
 from sharc.post_processor import PostProcessor
 
 from campaigns.mss_d2d_to_eess.constants import CAMPAIGN_DIR, SYS_ID_TO_READABLE, get_specific_pattern, MSS_ID_TO_READABLE
@@ -33,6 +33,12 @@ cdf_results = Results.load_many_from_dir(
     only_latest=True,
     only_samples=samples_for_cdf)
 
+for res in ccdf_results:
+    # converting dBm to dB
+    # TODO: update this after fixing unit problems at the SHARC simulator
+    res.system_dl_interf_power_per_mhz = SampleList(np.array(
+            res.system_dl_interf_power_per_mhz
+        ) - 30)
 
 def linestyle_getter(results):
     """

--- a/campaigns/mss_d2d_to_eess/plot_results.py
+++ b/campaigns/mss_d2d_to_eess/plot_results.py
@@ -149,6 +149,9 @@ system_dl_interf_power_per_mhz.add_hline(perc_time, line_dash="dash", annotation
     x=protection_criteria + 0.5, y=perc_time + 0.01,
     font=dict(size=12, color="blue")
 ))
+system_dl_interf_power_per_mhz.update_xaxes(
+    title_text="dB[W/MHz]",
+)
 
 
 attributes_to_plot = [
@@ -174,7 +177,9 @@ for attr, plot_type in attributes_to_plot:
         ticks='inside',
         showline=True,
         gridcolor="#DCDCDC",
-        gridwidth=1.5
+        gridwidth=1.5,
+        title_font=dict(size=16),
+        tickfont=dict(size=16),
     )
     plot.update_yaxes(
         linewidth=1,
@@ -192,9 +197,11 @@ for attr, plot_type in attributes_to_plot:
     )
     plot.update_layout(
         legend=dict(
-            font=dict(size=18),
-            x=0.01,
-            y=0.05,
+            font=dict(size=14),
+            x=0.2,
+            y=-0.5,
+            # xanchor='left',
+            orientation='h',
             xanchor='left',
             yanchor='bottom',
             bgcolor='rgba(255,255,255,0.7)',

--- a/campaigns/mss_d2d_to_eess/plot_results.py
+++ b/campaigns/mss_d2d_to_eess/plot_results.py
@@ -2,7 +2,7 @@ import os
 from sharc.results import Results
 from sharc.post_processor import PostProcessor
 
-from campaigns.mss_d2d_to_eess.constants import CAMPAIGN_DIR, SYS_ID_TO_READABLE
+from campaigns.mss_d2d_to_eess.constants import CAMPAIGN_DIR, SYS_ID_TO_READABLE, get_specific_pattern
 
 auto_open = True
 
@@ -59,17 +59,34 @@ for sys_name in [
     "eess.2200-2290MHz.system-B",
     "eess.2200-2290MHz.system-D",
 ]:
-    for elev in [5, 30, 60, 90, "uniform_"]:
-        if elev == "uniform_":
-            readable_elev = "Elev = Unif. Dist."
-        else:
-            readable_elev = f"Elev = {elev}º"
-        # IMT-MSS-D2D-DL to EESS
-        post_processor\
-            .add_plot_legend_pattern(
-                dir_name_contains=f"{elev}elev_{sys_name}",
-                legend=f"{SYS_ID_TO_READABLE[sys_name]}, {readable_elev}"
-            )
+    readable_sys = SYS_ID_TO_READABLE[sys_name]
+    for load in [
+        0.2,
+        0.5,
+        1
+    ]:
+        readable_load = f"Load = {load * 100}%"
+        for mask in [
+            "mss",
+            "3gpp",
+            "spurious",
+        ]:
+            readable_mask = {
+                "mss": "Mask = ITU-R SM.1541; @2197.5",
+                "3gpp": "Mask = 3GPP E-UTRA; @2197.5",
+                "spurious": "Mask = -13 dBm/MHz; @2167.5",
+            }[mask]
+            for elev in [5, 30, 60, 90, "uniform"]:
+                if elev == "uniform":
+                    readable_elev = "Elev = Unif. Dist."
+                else:
+                    readable_elev = f"Elev = {elev}º"
+                # IMT-MSS-D2D-DL to EESS
+                post_processor\
+                    .add_plot_legend_pattern(
+                        dir_name_contains=get_specific_pattern(elev, sys_name, mask, load),
+                        legend=f"{readable_sys}, {readable_elev}; MSS {readable_load}, {readable_mask}"
+                    )
 # ^: typing.List[Results]
 
 plots = post_processor.generate_ccdf_plots_from_results(

--- a/campaigns/mss_d2d_to_eess/plot_results.py
+++ b/campaigns/mss_d2d_to_eess/plot_results.py
@@ -165,7 +165,42 @@ HTMLS_DIR.mkdir(exist_ok=True)
 print(f"Saving plots in {HTMLS_DIR}")
 for attr, plot_type in attributes_to_plot:
     file = HTMLS_DIR / f"{attr}.html"
-    post_processor\
-        .get_plot_by_results_attribute_name(attr, plot_type=plot_type)\
-        .write_html(file=file, include_plotlyjs="cdn", auto_open=auto_open)
+    plot = post_processor.get_plot_by_results_attribute_name(attr, plot_type=plot_type)
+    # Add plot outline and increase font size
+    plot.update_xaxes(
+        linewidth=1,
+        linecolor='black',
+        mirror=True,
+        ticks='inside',
+        showline=True,
+        gridcolor="#DCDCDC",
+        gridwidth=1.5
+    )
+    plot.update_yaxes(
+        linewidth=1,
+        linecolor='black',
+        mirror=True,
+        ticks='inside',
+        showline=True,
+        gridcolor="#DCDCDC",
+        gridwidth=1.5
+    )
+    plot.update_layout(
+        xaxis_title_font=dict(size=24),
+        yaxis_title_font=dict(size=24),
+        template="plotly_white"
+    )
+    plot.update_layout(
+        legend=dict(
+            font=dict(size=18),
+            x=0.01,
+            y=0.05,
+            xanchor='left',
+            yanchor='bottom',
+            bgcolor='rgba(255,255,255,0.7)',
+            bordercolor='black',
+            borderwidth=1
+        )
+    )
+    plot.write_html(file=file, include_plotlyjs="cdn", auto_open=auto_open)
 

--- a/campaigns/mss_d2d_to_eess/run.py
+++ b/campaigns/mss_d2d_to_eess/run.py
@@ -1,11 +1,22 @@
+import argparse
+
 from sharc.run_multiple_campaigns_mut_thread import run_campaign
 
 from campaigns.mss_d2d_to_eess.generate_inputs import clear_inputs, generate_inputs
 from campaigns.mss_d2d_to_eess.constants import CAMPAIGN_NAME
 
 if __name__ == "__main__":
-    clear_inputs()
+    parser = argparse.ArgumentParser(description="MSS D2D to EESS cli")
 
-    generate_inputs()
+    parser.add_argument(
+        "-dg", "--dont-generate",
+        action="store_true",
+        help="Flag to not generate parameters before running (true/false). Default: false",
+    )
+
+    args = parser.parse_args()
+    if not args.dont_generate:
+        clear_inputs()
+        generate_inputs()
 
     run_campaign(CAMPAIGN_NAME)

--- a/campaigns/mss_d2d_to_eess/run.py
+++ b/campaigns/mss_d2d_to_eess/run.py
@@ -1,0 +1,11 @@
+from sharc.run_multiple_campaigns_mut_thread import run_campaign
+
+from campaigns.mss_d2d_to_eess.generate_inputs import clear_inputs, generate_inputs
+from campaigns.mss_d2d_to_eess.constants import CAMPAIGN_NAME
+
+if __name__ == "__main__":
+    clear_inputs()
+
+    generate_inputs()
+
+    run_campaign(CAMPAIGN_NAME)

--- a/from-docs/imt/imt.1-3GHz.single-bs.aas-macro-bs.yaml
+++ b/from-docs/imt/imt.1-3GHz.single-bs.aas-macro-bs.yaml
@@ -75,7 +75,7 @@ imt:
     # IMT and other services in adjacent band
     # Possible values: SINGLE_ELEMENT, BEAMFORMING
     adjacent_antenna_model: SINGLE_ELEMENT
-    # Base station parameters
+    # Base station parameters - Urban Macrocell
     bs:
         ###########################################################################
         # The load probability (or activity factor) models the statistical

--- a/from-docs/imt/imt.2110-2200MHz.mss-dc.system3-340km.yaml
+++ b/from-docs/imt/imt.2110-2200MHz.mss-dc.system3-340km.yaml
@@ -1,0 +1,321 @@
+# TODO: have an actual source of truth for equipment independent of topology
+# it may not even be possible though, considering SHARC's architecture
+id: imt.2110-2200MHz.mss-dc.system3-340km
+
+metadata:
+  referenced_documents:
+    - WP4C-Working-Document-4C-356, Annex 7
+  notes:
+    - If imt mss dc is `interfered_with`, imt_link should always be `UPLINK`
+    - If imt mss dc is not `interfered_with`, imt_link should always be `DOWNLINK`
+
+imt:
+    ###########################################################################
+    # Minimum 2D separation distance from BS to UE [m]
+    # NOTE: doesn't matter
+    minimum_separation_distance_bs_ue: 0
+    ###########################################################################
+    # Defines if IMT service is the interferer or interfered-with service
+    #   TRUE: IMT suffers interference
+    #   FALSE : IMT generates interference
+    interfered_with: TRUE
+    ###########################################################################
+    # IMT center frequency [MHz]
+    frequency: -1
+    ###########################################################################
+    # IMT bandwidth [MHz]
+    bandwidth: 5
+    ###########################################################################
+    # IMT resource block bandwidth [MHz]
+    # NOTE: only so that entire BW is taken by having integer number of RBs
+    rb_bandwidth: 0.1
+    # IMT resource block bandwidth [MHz]
+    adjacent_ch_reception: "OFF"
+    # IMT resource block bandwidth [MHz]
+    adjacent_ch_emissions: SPECTRAL_MASK
+    ###########################################################################
+    # IMT spectrum emission mask. Options are:
+    #   "IMT-2020" : for mmWave as described in ITU-R TG 5/1 Contribution 36
+    #   "3GPP E-UTRA" : for E-UTRA bands > 1 GHz as described in
+    #                   TS 36.104 v11.2.0 (BS) and TS 36.101 v11.2.0 (UE)
+    spectral_mask: MSS
+    ###########################################################################
+    # level of spurious emissions [dBm/MHz]
+    spurious_emissions: -13.0
+    ###########################################################################
+    # Amount of guard band wrt total bandwidth. Setting this parameter to 0.1
+    # means that 10% of the total bandwidth will be used as guard band: 5% in
+    # the lower
+    # NOTE: no guard band considered
+    guard_band_ratio: 0
+    ###########################################################################
+    # Network topology parameters.
+    topology:
+        ###########################################################################
+        # The latitude position is is_spherical is set to true
+        central_latitude: -25.5549751
+        ###########################################################################
+        # The longitude position is is_spherical is set to true
+        central_longitude: -54.5746686
+        ##########################
+        central_altitude: 200
+        ###########################################################################
+        # Topology Type. Possible values are "MACROCELL", "HOTSPOT", "SINGLE_BS"
+        # "INDOOR"
+        type: MSS_DC
+        ###########################################################################
+        # Macrocell Topology parameters. Relevant when imt.topology.type == "MACROCELL"
+        ###########################################################################
+        # Single Base Station Topology parameters. Relevant when imt.topology.type == "SINGLE_BS"
+        mss_dc:
+            orbits:
+                # Number of planes
+                - n_planes: 48
+                  # Inclination in degrees
+                  inclination_deg: 53.0
+                  # Perigee in km
+                  perigee_alt_km: 340.0
+                  # Apogee in km
+                  apogee_alt_km: 340.0
+                  # Number of satellites per plane
+                  sats_per_plane: 110
+                  # Longitude of the first ascending node in degrees
+                  long_asc_deg: 0.0
+                  # Phasing in degrees
+                  phasing_deg: 1.636
+            sat_is_active_if: # (PER SCENARIO)
+                # for a satellite to be active, it needs to respect ALL conditions
+                conditions:
+                    # - LAT_LONG_INSIDE_COUNTRY
+                    # - MAXIMUM_ELEVATION_FROM_ES
+                    - MINIMUM_ELEVATION_FROM_ES
+                minimum_elevation_from_es: 5
+                # maximum_elevation_from_es: 5
+                # lat_long_inside_country:
+                #     # You may specify another shp file for country borders reference
+                #     # country_shapes_filename: sharc/topology/countries/ne_110m_admin_0_countries.shp
+                #     country_names:
+                #         - Brazil
+                #         - Argentina
+                #     # margin from inside of border [km]
+                #     # if positive, makes border smaller by x km
+                #     # if negative, makes border bigger by x km
+                #     margin_from_border: 0
+    ###########################################################################
+    # Defines the antenna model to be used in compatibility studies between
+    # IMT and other services in adjacent band
+    # Possible values: SINGLE_ELEMENT, BEAMFORMING
+    adjacent_antenna_model: SINGLE_ELEMENT
+    # Base station parameters - MSS DC satellite
+    bs:
+        ###########################################################################
+        # The load probability (or activity factor) models the statistical
+        # variation of the network load by defining the number of fully loaded
+        # base stations that are simultaneously transmitting
+        load_probability: 1.0
+        ###########################################################################
+        # Conducted power per antenna element [dBm/bandwidth]
+        conducted_power: 41.4  # -55.6 [dB/Hz] + 10log(5*1e6)[Hz] + 30.0
+        ###########################################################################
+        # Base station height [m]
+        height: 340000 # VALUE NOT USED
+        ###########################################################################
+        # Base station noise figure [dB]
+        noise_figure: 5.0
+        ###########################################################################
+        # Base station array ohmic loss  [dB]
+        ohmic_loss: 0.0
+        # ###########################################################################
+        # # Adjacent channel selectivity
+        # adjacent_ch_selectivity: 46.0
+        ###########################################################################
+        # Base Station Antenna parameters:
+        antenna:
+            # for co-channel use Taylor
+            pattern: ITU-R-S.1528-Taylor
+            # Maximum Antenna gain in dBi
+            gain: 34.1
+            # NOTE: currently adjacent antenna pattern is
+            # M2101 single element
+            # this may not be the best modelling
+            # pattern: ARRAY
+            # NOTE: doc specifies lambda = 0.15m
+            # we calculate based on frequency, giving out approx. 0.14m
+            itu_r_s_1528:
+                ### The following parameters are used for S.1528-Taylor antenna pattern
+                # SLR is the side-lobe ratio of the pattern (dB), the difference in gain between the maximum
+                # gain and the gain at the peak of the first side lobe.
+                slr: 20.0
+                # Number of secondarylobes considered in the diagram (coincide with the roots of the Bessel function)
+                n_side_lobes: 2
+                # Radial (l_r) and transverse (l_t) sizes of the effective radiating area of the satellite transmitt antenna (m)
+                l_r: 1.6
+                l_t: 1.6
+            array:
+                ###########################################################################
+                # If normalization of M2101 should be applied for BS
+                normalization: FALSE
+                ###########################################################################
+                # Radiation pattern of each antenna element
+                # Possible values: "M2101", "F1336", "FIXED"
+                element_pattern: M2101
+                ###########################################################################
+                # BS/UE maximum transmit/receive element gain [dBi]
+                # default: element_max_g = 5, for M.2101
+                #                           = 15, for M.2292
+                #                           = -3, for M.2292
+                element_max_g: 6.4
+                ###########################################################################
+                # BS/UE horizontal 3dB beamwidth of single element [degrees]
+                element_phi_3db: 90
+                ###########################################################################
+                # BS/UE vertical 3dB beamwidth of single element [degrees]
+                # For F1336: if equal to 0, then beamwidth is calculated automaticaly
+                element_theta_3db: 65
+                ###########################################################################
+                # BS/UE number of rows in antenna array
+                n_rows: 1
+                ###########################################################################
+                # BS/UE number of columns in antenna array
+                n_columns: 1
+                ###########################################################################
+                # BS/UE front to back ratio of single element [dB]
+                element_am: 30
+                ###########################################################################
+                # BS/UE single element vertical sidelobe attenuation [dB]
+                element_sla_v: 30
+                ###########################################################################
+                # Multiplication factor k that is used to adjust the single-element pattern.
+                # According to Report ITU-R M.[IMT.AAS], this may give a closer match of the 
+                # side lobes when beamforming is assumed in adjacent channel.
+                #       Original value: 12 (Rec. ITU-R M.2101)
+                multiplication_factor: 12
+
+    ###########################################################################
+    # User Equipment parameters:
+    # NOTE: not important since this file should always be used for DOWNLINK sim
+    ue:
+        ###########################################################################
+        # Number of UEs that are allocated to each cell within handover margin.
+        # Remember that in macrocell network each base station has 3 cells (sectors)
+        # NOTE: we should use 1 here only for performance reasons
+        # since beamforming is not 
+        k: 1
+        ###########################################################################
+        # Multiplication factor that is used to ensure that the sufficient number
+        # of UE's will distributed throughout ths system area such that the number
+        # of K users is allocated to each cell. Normally, this values varies
+        # between 2 and 10 according to the user drop method
+        k_m: 1
+        ###########################################################################
+        # Percentage of indoor UE's [%]
+        indoor_percent: 0.0
+        ###########################################################################
+        # Regarding the distribution of active UE's over the cell area, this
+        # parameter states how the UEs will be distributed
+        # Possible values: UNIFORM : UEs will be uniformly distributed within the
+        #                            whole simulation area. Not applicable to
+        #                            hotspots.
+        #                  ANGLE_AND_DISTANCE : UEs will be distributed following
+        #                                   given distributions for angle and
+        #                                   distance. In this case, these must be
+        #                                   defined later.
+        distribution_type: UNIFORM_IN_CELL
+        ###########################################################################
+        # Regarding the distribution of active UE's over the cell area, this
+        # parameter models the distance between UE's and BS.
+        # Possible values: RAYLEIGH, UNIFORM
+        distribution_distance: RAYLEIGH
+        ###########################################################################
+        # Regarding the distribution of active UE's over the cell area, this
+        # parameter models the azimuth between UE and BS (within ±60° range).
+        # Possible values: NORMAL, UNIFORM
+        distribution_azimuth: UNIFORM
+        ###########################################################################
+        # Power control algorithm
+        # tx_power_control = "ON",power control On
+        # tx_power_control = "OFF",power control Off
+        tx_power_control: OFF
+        ###########################################################################
+        # Power per RB used as target value [dBm]
+        p_o_pusch: -92.2
+        ###########################################################################
+        # Alfa is the balancing factor for UEs with bad channel
+        # and UEs with good channel
+        alpha: 0.8
+        ###########################################################################
+        # Maximum UE transmit power [dBm]
+        p_cmax: 23
+        ###########################################################################
+        # UE power dynamic range [dB]
+        # The minimum transmit power of a UE is (p_cmax - dynamic_range)
+        power_dynamic_range: 63
+        ###########################################################################
+        # UE height [m]
+        height: 1.5
+        ###########################################################################
+        # User equipment noise figure [dB]
+        noise_figure: 9
+        ###########################################################################
+        # User equipment feed loss [dB]
+        ohmic_loss: 0
+        ###########################################################################
+        # User equipment body loss [dB]
+        body_loss: 4
+        antenna:
+            array:
+                ###########################################################################
+                # Radiation pattern of each antenna element
+                # Possible values: "M2101", "F1336", "FIXED"
+                element_pattern: FIXED
+                ###########################################################################
+                # BS/UE maximum transmit/receive element gain [dBi]
+                #                           = 15, for M.2292
+                # default: element_max_g = 5, for M.2101
+                #                           = -3, for M.2292
+                element_max_g: -3
+                ###########################################################################
+                # BS/UE number of rows in antenna array
+                n_rows: 1
+                ###########################################################################
+                # BS/UE number of columns in antenna array
+                n_columns: 1
+    ###########################################################################
+    # Uplink parameters. Only needed when using uplink on imt
+    uplink:
+        ###########################################################################
+        # Uplink attenuation factor used in link-to-system mapping
+        attenuation_factor: 0.4
+        ###########################################################################
+        # Uplink minimum SINR of the code set [dB]
+        sinr_min: -10
+        ###########################################################################
+        # Uplink maximum SINR of the code set [dB]
+        sinr_max: 22
+    ###########################################################################
+    # Downlink parameters. Only needed when using donwlink on imt
+    downlink:
+        ###########################################################################
+        # Downlink attenuation factor used in link-to-system mapping
+        attenuation_factor: 0.8
+        ###########################################################################
+        # Downlink minimum SINR of the code set [dB]
+        sinr_min: -10
+        ###########################################################################
+        # Downlink maximum SINR of the code set [dB]
+        sinr_max: 30
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "CI" (close-in FS reference distance)
+    #                                    "UMa" (Urban Macro - 3GPP)
+    #                                    "UMi" (Urban Micro - 3GPP)
+    #                                    "TVRO-URBAN"
+    #                                    "TVRO-SUBURBAN"
+    #                                    "ABG" (Alpha-Beta-Gamma)
+    #                                    "P619"
+    channel_model: FSPL
+    ###########################################################################
+    # receiver noise temperature [K]
+    noise_temperature: 290
+

--- a/from-docs/imt/imt.2110-2200MHz.mss-dc.system3-525km.yaml
+++ b/from-docs/imt/imt.2110-2200MHz.mss-dc.system3-525km.yaml
@@ -1,0 +1,320 @@
+# TODO: have an actual source of truth for equipment independent of topology
+# it may not even be possible though, considering SHARC's architecture
+id: imt.2110-2200MHz.mss-dc.system3-525km
+
+metadata:
+  referenced_documents:
+    - WP4C-Working-Document-4C-356, Annex 7
+  notes:
+    - If imt mss dc is `interfered_with`, imt_link should always be `UPLINK`
+    - If imt mss dc is not `interfered_with`, imt_link should always be `DOWNLINK`
+
+imt:
+    ###########################################################################
+    # Minimum 2D separation distance from BS to UE [m]
+    # NOTE: doesn't matter
+    minimum_separation_distance_bs_ue: 0
+    ###########################################################################
+    # Defines if IMT service is the interferer or interfered-with service
+    #   TRUE: IMT suffers interference
+    #   FALSE : IMT generates interference
+    interfered_with: TRUE
+    ###########################################################################
+    # IMT center frequency [MHz]
+    frequency: -1
+    ###########################################################################
+    # IMT bandwidth [MHz]
+    bandwidth: 5
+    ###########################################################################
+    # IMT resource block bandwidth [MHz]
+    # NOTE: only so that entire BW is taken by having integer number of RBs
+    rb_bandwidth: 0.1
+    # IMT resource block bandwidth [MHz]
+    adjacent_ch_reception: "OFF"
+    # IMT resource block bandwidth [MHz]
+    adjacent_ch_emissions: SPECTRAL_MASK
+    ###########################################################################
+    # IMT spectrum emission mask. Options are:
+    #   "IMT-2020" : for mmWave as described in ITU-R TG 5/1 Contribution 36
+    #   "3GPP E-UTRA" : for E-UTRA bands > 1 GHz as described in
+    #                   TS 36.104 v11.2.0 (BS) and TS 36.101 v11.2.0 (UE)
+    spectral_mask: MSS
+    ###########################################################################
+    # level of spurious emissions [dBm/MHz]
+    spurious_emissions: -13.0
+    ###########################################################################
+    # Amount of guard band wrt total bandwidth. Setting this parameter to 0.1
+    # means that 10% of the total bandwidth will be used as guard band: 5% in
+    # the lower
+    # NOTE: no guard band considered
+    guard_band_ratio: 0
+    ###########################################################################
+    # Network topology parameters.
+    topology:
+        ###########################################################################
+        # The latitude position is is_spherical is set to true
+        central_latitude: -25.5549751
+        ###########################################################################
+        # The longitude position is is_spherical is set to true
+        central_longitude: -54.5746686
+        ##########################
+        central_altitude: 200
+        ###########################################################################
+        # Topology Type. Possible values are "MACROCELL", "HOTSPOT", "SINGLE_BS"
+        # "INDOOR"
+        type: MSS_DC
+        ###########################################################################
+        # Macrocell Topology parameters. Relevant when imt.topology.type == "MACROCELL"
+        ###########################################################################
+        # Single Base Station Topology parameters. Relevant when imt.topology.type == "SINGLE_BS"
+        mss_dc:
+            orbits:
+                # Number of planes
+              - n_planes: 28
+                # Inclination in degrees
+                inclination_deg: 53.0
+                # Perigee in km
+                perigee_alt_km: 525.0
+                # Apogee in km
+                apogee_alt_km: 525.0
+                # Number of satellites per plane
+                sats_per_plane: 120
+                # Longitude of the first ascending node in degrees
+                long_asc_deg: 0.0
+                # Phasing in degrees
+                phasing_deg: 1.5
+            sat_is_active_if: # (PER SCENARIO)
+                # for a satellite to be active, it needs to respect ALL conditions
+                conditions:
+                    # - LAT_LONG_INSIDE_COUNTRY
+                    # - MAXIMUM_ELEVATION_FROM_ES
+                    - MINIMUM_ELEVATION_FROM_ES
+                minimum_elevation_from_es: 5
+                # maximum_elevation_from_es: 5
+                # lat_long_inside_country:
+                #     # You may specify another shp file for country borders reference
+                #     # country_shapes_filename: sharc/topology/countries/ne_110m_admin_0_countries.shp
+                #     country_names:
+                #         - Brazil
+                #         - Argentina
+                #     # margin from inside of border [km]
+                #     # if positive, makes border smaller by x km
+                #     # if negative, makes border bigger by x km
+                #     margin_from_border: 0
+    ###########################################################################
+    # Defines the antenna model to be used in compatibility studies between
+    # IMT and other services in adjacent band
+    # Possible values: SINGLE_ELEMENT, BEAMFORMING
+    adjacent_antenna_model: SINGLE_ELEMENT
+    # Base station parameters - MSS DC satellite
+    bs:
+        ###########################################################################
+        # The load probability (or activity factor) models the statistical
+        # variation of the network load by defining the number of fully loaded
+        # base stations that are simultaneously transmitting
+        load_probability: 1.0
+        ###########################################################################
+        # Conducted power per antenna element [dBm/bandwidth]
+        conducted_power: 41.4  # -55.6 [dB/Hz] + 10log(5*1e6)[Hz] + 30.0
+        ###########################################################################
+        # Base station height [m]
+        height: 525000 # VALUE NOT USED
+        ###########################################################################
+        # Base station noise figure [dB]
+        noise_figure: 5.0
+        ###########################################################################
+        # Base station array ohmic loss  [dB]
+        ohmic_loss: 0.0
+        # ###########################################################################
+        # # Adjacent channel selectivity
+        # adjacent_ch_selectivity: 46.0
+        ###########################################################################
+        # Base Station Antenna parameters:
+        antenna:
+            # for co-channel use Taylor
+            pattern: ITU-R-S.1528-Taylor
+            # Maximum Antenna gain in dBi
+            gain: 34.1
+            # NOTE: currently adjacent antenna pattern is
+            # M2101 single element
+            # this may not be the best modelling
+            # pattern: ARRAY
+            # NOTE: doc specifies lambda = 0.15m
+            # we calculate based on frequency, giving out approx. 0.14m
+            itu_r_s_1528:
+                ### The following parameters are used for S.1528-Taylor antenna pattern
+                # SLR is the side-lobe ratio of the pattern (dB), the difference in gain between the maximum
+                # gain and the gain at the peak of the first side lobe.
+                slr: 20.0
+                # Number of secondarylobes considered in the diagram (coincide with the roots of the Bessel function)
+                n_side_lobes: 2
+                # Radial (l_r) and transverse (l_t) sizes of the effective radiating area of the satellite transmitt antenna (m)
+                l_r: 1.6
+                l_t: 1.6
+            array:
+                ###########################################################################
+                # If normalization of M2101 should be applied for BS
+                normalization: FALSE
+                ###########################################################################
+                # Radiation pattern of each antenna element
+                # Possible values: "M2101", "F1336", "FIXED"
+                element_pattern: M2101
+                ###########################################################################
+                # BS/UE maximum transmit/receive element gain [dBi]
+                # default: element_max_g = 5, for M.2101
+                #                           = 15, for M.2292
+                #                           = -3, for M.2292
+                element_max_g: 6.4
+                ###########################################################################
+                # BS/UE horizontal 3dB beamwidth of single element [degrees]
+                element_phi_3db: 90
+                ###########################################################################
+                # BS/UE vertical 3dB beamwidth of single element [degrees]
+                # For F1336: if equal to 0, then beamwidth is calculated automaticaly
+                element_theta_3db: 65
+                ###########################################################################
+                # BS/UE number of rows in antenna array
+                n_rows: 1
+                ###########################################################################
+                # BS/UE number of columns in antenna array
+                n_columns: 1
+                ###########################################################################
+                # BS/UE front to back ratio of single element [dB]
+                element_am: 30
+                ###########################################################################
+                # BS/UE single element vertical sidelobe attenuation [dB]
+                element_sla_v: 30
+                ###########################################################################
+                # Multiplication factor k that is used to adjust the single-element pattern.
+                # According to Report ITU-R M.[IMT.AAS], this may give a closer match of the 
+                # side lobes when beamforming is assumed in adjacent channel.
+                #       Original value: 12 (Rec. ITU-R M.2101)
+                multiplication_factor: 12
+
+    ###########################################################################
+    # User Equipment parameters:
+    # NOTE: not important since this file should always be used for DOWNLINK sim
+    ue:
+        ###########################################################################
+        # Number of UEs that are allocated to each cell within handover margin.
+        # Remember that in macrocell network each base station has 3 cells (sectors)
+        # NOTE: we should use 1 here only for performance reasons
+        # since beamforming is not 
+        k: 1
+        ###########################################################################
+        # Multiplication factor that is used to ensure that the sufficient number
+        # of UE's will distributed throughout ths system area such that the number
+        # of K users is allocated to each cell. Normally, this values varies
+        # between 2 and 10 according to the user drop method
+        k_m: 1
+        ###########################################################################
+        # Percentage of indoor UE's [%]
+        indoor_percent: 0.0
+        ###########################################################################
+        # Regarding the distribution of active UE's over the cell area, this
+        # parameter states how the UEs will be distributed
+        # Possible values: UNIFORM : UEs will be uniformly distributed within the
+        #                            whole simulation area. Not applicable to
+        #                            hotspots.
+        #                  ANGLE_AND_DISTANCE : UEs will be distributed following
+        #                                   given distributions for angle and
+        #                                   distance. In this case, these must be
+        #                                   defined later.
+        distribution_type: UNIFORM_IN_CELL
+        ###########################################################################
+        # Regarding the distribution of active UE's over the cell area, this
+        # parameter models the distance between UE's and BS.
+        # Possible values: RAYLEIGH, UNIFORM
+        distribution_distance: RAYLEIGH
+        ###########################################################################
+        # Regarding the distribution of active UE's over the cell area, this
+        # parameter models the azimuth between UE and BS (within ±60° range).
+        # Possible values: NORMAL, UNIFORM
+        distribution_azimuth: UNIFORM
+        ###########################################################################
+        # Power control algorithm
+        # tx_power_control = "ON",power control On
+        # tx_power_control = "OFF",power control Off
+        tx_power_control: OFF
+        ###########################################################################
+        # Power per RB used as target value [dBm]
+        p_o_pusch: -92.2
+        ###########################################################################
+        # Alfa is the balancing factor for UEs with bad channel
+        # and UEs with good channel
+        alpha: 0.8
+        ###########################################################################
+        # Maximum UE transmit power [dBm]
+        p_cmax: 23
+        ###########################################################################
+        # UE power dynamic range [dB]
+        # The minimum transmit power of a UE is (p_cmax - dynamic_range)
+        power_dynamic_range: 63
+        ###########################################################################
+        # UE height [m]
+        height: 1.5
+        ###########################################################################
+        # User equipment noise figure [dB]
+        noise_figure: 9
+        ###########################################################################
+        # User equipment feed loss [dB]
+        ohmic_loss: 0
+        ###########################################################################
+        # User equipment body loss [dB]
+        body_loss: 4
+        antenna:
+            array:
+                ###########################################################################
+                # Radiation pattern of each antenna element
+                # Possible values: "M2101", "F1336", "FIXED"
+                element_pattern: FIXED
+                ###########################################################################
+                # BS/UE maximum transmit/receive element gain [dBi]
+                #                           = 15, for M.2292
+                # default: element_max_g = 5, for M.2101
+                #                           = -3, for M.2292
+                element_max_g: -3
+                ###########################################################################
+                # BS/UE number of rows in antenna array
+                n_rows: 1
+                ###########################################################################
+                # BS/UE number of columns in antenna array
+                n_columns: 1
+    ###########################################################################
+    # Uplink parameters. Only needed when using uplink on imt
+    uplink:
+        ###########################################################################
+        # Uplink attenuation factor used in link-to-system mapping
+        attenuation_factor: 0.4
+        ###########################################################################
+        # Uplink minimum SINR of the code set [dB]
+        sinr_min: -10
+        ###########################################################################
+        # Uplink maximum SINR of the code set [dB]
+        sinr_max: 22
+    ###########################################################################
+    # Downlink parameters. Only needed when using donwlink on imt
+    downlink:
+        ###########################################################################
+        # Downlink attenuation factor used in link-to-system mapping
+        attenuation_factor: 0.8
+        ###########################################################################
+        # Downlink minimum SINR of the code set [dB]
+        sinr_min: -10
+        ###########################################################################
+        # Downlink maximum SINR of the code set [dB]
+        sinr_max: 30
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "CI" (close-in FS reference distance)
+    #                                    "UMa" (Urban Macro - 3GPP)
+    #                                    "UMi" (Urban Micro - 3GPP)
+    #                                    "TVRO-URBAN"
+    #                                    "TVRO-SUBURBAN"
+    #                                    "ABG" (Alpha-Beta-Gamma)
+    #                                    "P619"
+    channel_model: FSPL
+    ###########################################################################
+    # receiver noise temperature [K]
+    noise_temperature: 290

--- a/from-docs/system/eess/eess.2200-2290MHz.system-B.yaml
+++ b/from-docs/system/eess/eess.2200-2290MHz.system-B.yaml
@@ -1,0 +1,65 @@
+#### EESS Parameters @2GHz
+# Single Earth Station representing an EESS Earth Station in the 2.0 GHz band.
+# Referce data comes from the REPLY LIAISON STATEMENT TO WORKING PARTY 4C ON
+# WRC-27 AGENDA ITEMS 1.12, 1.13, 1.14 AND 1.15 - Document 4C/196-E
+# System B is specified in the document 4C/196-E - Annex 2 - Table 2
+id: eess.2200-2290MHz.system-B
+
+metadata:
+  referenced_documents:
+    - 4C/196-E
+  created_at: 23-07-2025
+
+single_earth_station:
+  frequency: 2200  # MHz
+  bandwidth: 4  # MHz
+  # tx power density just so simulator runs
+  tx_power_density: -200
+  # also just so simulator runs
+  noise_temperature: 190
+  # This is based in pratical data found in other documents.
+  # 35-45dBs are generally assumed. We take 35 as a worst case.
+  adjacent_ch_selectivity: 35
+  # Channel model
+  channel_model: FSPL
+  param_satellite_simple:
+    # Enable clutter loss
+    enable_clutter_loss: false
+    # Atmospheric loss in dB
+    atmospheric_loss: 0.65
+  # NOTE: when using P.619 it is suggested that polarization loss = 3dB is good
+  polarization_loss: 0
+  # Earth Station parameters
+  geometry:
+    height: 7
+    azimuth:
+      # Type of elevation.
+      type: UNIFORM_DIST
+      uniform_dist:
+        max: 180
+        min: -180
+    # Elevation angle [degrees]
+    elevation:
+      # Type of elevation.
+      type: FIXED
+      fixed: 90
+    # Station 2d location [meters]:
+    location:
+      type: FIXED
+      fixed:
+        x: 0
+        y: 0
+  antenna:
+      ###########################################################################
+      # Choose the antenna pattern. Can be one of:
+      # "OMNI", "ITU-R F.699", "ITU-R S.465", "ITU-R S.580", "MODIFIED ITU-R S.465",
+      # "ITU-R S.1855", "ITU-R S.672"
+      # since 20deg beamwidth would already cover every area
+      pattern: ITU-R S.465
+      ###########################################################################
+      # Station peak receive antenna gain [dBi]
+      gain: 45.8
+      itu_r_s_465:
+        # Diameter [m]
+        diameter: 12  # derived with efficiency 0.5
+

--- a/from-docs/system/eess/eess.2200-2290MHz.system-B.yaml
+++ b/from-docs/system/eess/eess.2200-2290MHz.system-B.yaml
@@ -7,11 +7,10 @@ id: eess.2200-2290MHz.system-B
 
 metadata:
   referenced_documents:
-    - 4C/196-E
-  created_at: 23-07-2025
+    - 4C/196-E - Annex 2 - Table 2
 
 single_earth_station:
-  frequency: 2200  # MHz
+  frequency: 2202  # MHz
   bandwidth: 4  # MHz
   # tx power density just so simulator runs
   tx_power_density: -200
@@ -22,11 +21,6 @@ single_earth_station:
   adjacent_ch_selectivity: 35
   # Channel model
   channel_model: FSPL
-  param_satellite_simple:
-    # Enable clutter loss
-    enable_clutter_loss: false
-    # Atmospheric loss in dB
-    atmospheric_loss: 0.65
   # NOTE: when using P.619 it is suggested that polarization loss = 3dB is good
   polarization_loss: 0
   # Earth Station parameters
@@ -62,4 +56,3 @@ single_earth_station:
       itu_r_s_465:
         # Diameter [m]
         diameter: 12  # derived with efficiency 0.5
-

--- a/from-docs/system/eess/eess.2200-2290MHz.system-D.yaml
+++ b/from-docs/system/eess/eess.2200-2290MHz.system-D.yaml
@@ -55,5 +55,5 @@ single_earth_station:
       gain: 39
       itu_r_s_465:
         # Diameter [m]
-        diameter: 12  # derived with efficiency 0.5
+        diameter: 5.5  # derived with efficiency 0.5
 

--- a/from-docs/system/eess/eess.2200-2290MHz.system-D.yaml
+++ b/from-docs/system/eess/eess.2200-2290MHz.system-D.yaml
@@ -1,0 +1,59 @@
+#### EESS Parameters @2GHz
+# Single Earth Station representing an EESS Earth Station in the 2.0 GHz band.
+# Referce data comes from the REPLY LIAISON STATEMENT TO WORKING PARTY 4C ON
+# WRC-27 AGENDA ITEMS 1.12, 1.13, 1.14 AND 1.15 - Document 4C/196-E
+# System D is specified in the document 4C/196-E - Annex 2 - Table 2
+id: eess.2200-2290MHz.system-D
+
+metadata:
+  referenced_documents:
+    - 4C/196-E - Annex 2 - Table 2
+
+single_earth_station:
+  frequency: 2202  # MHz
+  bandwidth: 6  # MHz
+  # tx power density just so simulator runs
+  tx_power_density: -200
+  # also just so simulator runs
+  noise_temperature: 120
+  # This is based in pratical data found in other documents.
+  # 35-45dBs are generally assumed. We take 35 as a worst case.
+  adjacent_ch_selectivity: 35
+  # Channel model
+  channel_model: FSPL
+  # NOTE: when using P.619 it is suggested that polarization loss = 3dB is good
+  polarization_loss: 0
+  # Earth Station parameters
+  geometry:
+    height: 7
+    azimuth:
+      # Type of elevation.
+      type: UNIFORM_DIST
+      uniform_dist:
+        max: 180
+        min: -180
+    # Elevation angle [degrees]
+    elevation:
+      # Type of elevation.
+      type: FIXED
+      fixed: 90
+    # Station 2d location [meters]:
+    location:
+      type: FIXED
+      fixed:
+        x: 0
+        y: 0
+  antenna:
+      ###########################################################################
+      # Choose the antenna pattern. Can be one of:
+      # "OMNI", "ITU-R F.699", "ITU-R S.465", "ITU-R S.580", "MODIFIED ITU-R S.465",
+      # "ITU-R S.1855", "ITU-R S.672"
+      # since 20deg beamwidth would already cover every area
+      pattern: ITU-R S.465
+      ###########################################################################
+      # Station peak receive antenna gain [dBi]
+      gain: 39
+      itu_r_s_465:
+        # Diameter [m]
+        diameter: 12  # derived with efficiency 0.5
+


### PR DESCRIPTION
Feat: new campaign

Mss DC -> EESS ES

Documents used for the equipment parameters are cited within the `yaml`s.

Diffing between the currently generated parameters and the previous campaign iteration (on https://github.com/Radio-Spectrum/SHARC/tree/feat/mss_dc_to_eess/) is detailed in the zipped folder:
[comparing-to-prev.zip](https://github.com/user-attachments/files/21537224/comparing-to-prev.zip)

It is unnecessary to examine all input files in the zip since they're all really similar.

Example diffing:
```yaml
'[+] metadata':
  based_on_ids:
  - imt.2110-2200MHz.mss-dc.system3-525km
  - eess.2200-2290MHz.system-B
  eess.2200-2290MHz.system-B:
    referenced_documents:
    - 4C/196-E - Annex 2 - Table 2
  imt.2110-2200MHz.mss-dc.system3-525km:
    notes:
    - If imt mss dc is `interfered_with`, imt_link should always be `UPLINK`
    - If imt mss dc is not `interfered_with`, imt_link should always be `DOWNLINK`
    referenced_documents:
    - WP4C-Working-Document-4C-356, Annex 7
general:
  '[M] output_dir_prefix': output_mss_d2d_to_eess_30elev_system_b -> output_mss_d2d_to_eess_30elev_eess.2200-2290MHz.system-B
  '[M] seed': 681603 -> 15728327
imt:
  '[-] adjacent_ch_leak_ratio': 50.0
  '[-] los_adjustment_factor': 18
  '[-] param_p619':
    earth_station_alt_m: 1200
    earth_station_lat_deg: 13
    earth_station_long_diff_deg: 0
    space_station_alt_m: 540000
  '[-] season': SUMMER
  '[-] shadowing': false
  '[M] adjacent_ch_reception': ACS -> OFF
  '[M] frequency': 2167.5 -> 2160.0
  '[M] guard_band_ratio': 0.1 -> 0
  '[M] minimum_separation_distance_bs_ue': 35 -> 0
  '[M] rb_bandwidth': 0.18 -> 0.1
  bs:
    '[M] height': 20.0 -> 525000
    '[M] ohmic_loss': 3.0 -> 0.0
    antenna:
      '[+] gain': 34.1
      '[+] itu_r_s_1528':
        frequency: 2160.0
        l_r: 1.6
        l_t: 1.6
        n_side_lobes: 2
        slr: 20.0
      '[M] pattern': ARRAY -> ITU-R-S.1528-Taylor
      array:
        '[-] downtilt': 0.0
        '[-] element_horiz_spacing': 0.5
        '[-] element_vert_spacing': 2.1
        '[-] horizontal_beamsteering_range': !!python/tuple
        - -60.0
        - 60.0
        '[-] minimum_array_gain': -200
        '[-] normalization_file': antenna/beamforming_normalization/bs_norm.npz
        '[-] subarray':
          element_vert_spacing: 0.7
          eletrical_downtilt: 3.0
          is_enabled: false
          n_rows: 3
        '[-] vertical_beamsteering_range': !!python/tuple
        - 90.0
        - 100.0
  topology:
    mss_dc:
      '[-] num_beams': 1
      '[M] beam_radius': 39475.0 -> 36726
      beam_positioning:
        service_grid:
          '[+] country_names':
          - Brazil
          '[M] eligible_sats_margin_from_border': -731 -> -714
      sat_is_active_if:
        lat_long_inside_country:
          '[M] margin_from_border': 40 -> -714
  ue:
    '[M] tx_power_control': True -> False
    antenna:
      array:
        '[-] element_am': 25
        '[-] element_horiz_spacing': 0.5
        '[-] element_phi_3db': 90
        '[-] element_sla_v': 25
        '[-] element_theta_3db': 90
        '[-] element_vert_spacing': 0.5
        '[-] minimum_array_gain': -200
        '[-] multiplication_factor': 12
        '[-] normalization': false
        '[-] normalization_file': antenna/beamforming_normalization/ue_norm.npz
single_earth_station:
  '[+] adjacent_ch_reception': ACS
  '[+] param_p619':
    below_rooftop: 0
    earth_station_alt_m: 563
    earth_station_lat_deg: -22.681603
    mean_clutter_height: low
  '[+] season': SUMMER
  '[-] param_satellite_simple':
    atmospheric_loss: 0.65
    enable_clutter_loss: false
  '[M] channel_model': FSPL -> P619
  '[M] frequency': 2200 -> 2202.0
  '[M] polarization_loss': 0 -> 3
  antenna:
    itu_r_s_465:
      '[M] diameter': 11.97 -> 11.96
  geometry:
    '[M] height': 7 -> 15
```
